### PR TITLE
Document configurable global roles

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = $(shell if [ -x .venv/bin/sphinx-build ]; then echo .venv/bin/sphinx-build; else echo sphinx-build; fi)
+SPHINXAUTOBUILD = $(shell if [ -x .venv/bin/sphinx-autobuild ]; then echo .venv/bin/sphinx-autobuild; else echo sphinx-autobuild; fi)
 SOURCEDIR     = .
 BUILDDIR      = _build
 
@@ -16,7 +17,7 @@ help:
 
 .PHONY: watch
 watch:
-	sphinx-autobuild . _build/html
+	$(SPHINXAUTOBUILD) "$(SOURCEDIR)" "$(BUILDDIR)/html"
 
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = $(shell if [ -x .venv/bin/sphinx-build ]; then echo .venv/bin/sphinx-build; else echo sphinx-build; fi)
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/docs/application/administration/index.rst
+++ b/docs/application/administration/index.rst
@@ -3,7 +3,7 @@
 Administration
 **************
 
-Administration section serves as the name suggests to admins with managing the |project_name| instance. By navigating via :guilabel:`Administration` item from the main menu, we can manage the things listed below.
+Administration section serves as the name suggests to users with permission to manage the |project_name| instance. By navigating via :guilabel:`Administration` item from the main menu, we can manage the things listed below.
 
 ----
 
@@ -16,5 +16,6 @@ Administration section serves as the name suggests to admins with managing the |
     :maxdepth: 2
 
     settings/index
+    roles/index
     users/index
     locales/index

--- a/docs/application/administration/roles/index.rst
+++ b/docs/application/administration/roles/index.rst
@@ -14,7 +14,7 @@ New |project_name| instances include default roles for the usual workflows:
 - **Data Steward** for users who prepare content such as knowledge models, document templates, and project templates.
 - **Admin** for users who manage the instance.
 
-The **Admin** role is special. It has all permissions available in role management and cannot be changed or deleted. Other default roles can be adjusted or deleted if they are not assigned to users and are not configured as the default role for new users.
+The **Admin** role cannot be changed or deleted. Other default roles can be adjusted or deleted if they are not assigned to users and are not configured as the default role for new users.
 
 Custom Roles
 ============

--- a/docs/application/administration/roles/index.rst
+++ b/docs/application/administration/roles/index.rst
@@ -1,0 +1,90 @@
+.. _roles:
+
+Roles
+*****
+
+Roles define what users can do across the |project_name| instance. Each user has one global role. The role contains a set of permissions, such as whether the user can manage users, configure settings, work with knowledge models, or access all projects.
+
+Default Roles
+=============
+
+New |project_name| instances include default roles for the usual workflows:
+
+- **Researcher** for users who mainly create and work on their own projects.
+- **Data Steward** for users who prepare content such as knowledge models, document templates, and project templates.
+- **Admin** for users who manage the instance.
+
+The **Admin** role is special. It has all regular permissions and cannot be changed or deleted. Other default roles can be adjusted or deleted if they are not assigned to users and are not configured as the default role for new users.
+
+Custom Roles
+============
+
+Users with permission to manage settings can create custom roles when the default roles do not match the way an organization works. A role has a name, an optional description, and selected permissions.
+
+Custom roles are useful for cases such as:
+
+- a data support role that can view or comment on all projects
+- a user-management role that can manage users without managing settings
+- an analytics role that can access reporting without broader administration access
+- a content-management role that can work with knowledge models or document templates
+
+.. TODO::
+
+    Add a screenshot of the roles list showing default roles, custom roles, and the number of users assigned to each role.
+
+Role Permissions
+================
+
+Permissions are grouped by the type of work they enable. The available groups depend on the |project_name| edition and enabled features.
+
+Project-related permissions can allow a role to:
+
+- manage project templates
+- view all projects
+- comment on all projects
+- edit all projects
+- manage all projects
+
+Content-related permissions can allow a role to:
+
+- create and use knowledge model editors
+- manage knowledge models
+- manage knowledge model secrets
+- create and use document template editors
+- manage document templates
+- manage locales
+
+Administration permissions can allow a role to:
+
+- manage users
+- manage settings
+- manage automations
+- access audit log
+- access integration hub
+- access analytics
+
+.. TODO::
+
+    Add a screenshot of the role create/edit form with permission groups and toggles visible.
+
+Global Roles and Project Sharing
+================================
+
+Global roles and :ref:`project sharing<sharing>` are related but separate.
+
+Project sharing controls access to a specific project. It is used for inviting collaborators as viewers, commenters, editors, or owners.
+
+Global role permissions can grant access across projects. For example, a role may allow a user to view, comment on, edit, or manage all projects in the instance. In that case, the user does not need to be listed explicitly in every project's sharing settings for that level of access.
+
+Project sharing is still used to manage collaboration inside a specific project, especially for project ownership and external/public access.
+
+Editing Roles
+=============
+
+When a role is changed, users assigned to that role receive the updated permissions. Before changing a role, check how many users are assigned to it.
+
+A role cannot be deleted if it is assigned to users. A role also cannot be deleted if it is configured as the :ref:`default role<authentication>` for new users.
+
+.. TODO::
+
+    Add a screenshot of a role detail page or edit form showing a role that cannot be deleted because it is assigned to users.

--- a/docs/application/administration/roles/index.rst
+++ b/docs/application/administration/roles/index.rst
@@ -14,7 +14,7 @@ New |project_name| instances include default roles for the usual workflows:
 - **Data Steward** for users who prepare content such as knowledge models, document templates, and project templates.
 - **Admin** for users who manage the instance.
 
-The **Admin** role is special. It has all regular permissions and cannot be changed or deleted. Other default roles can be adjusted or deleted if they are not assigned to users and are not configured as the default role for new users.
+The **Admin** role is special. It has all permissions available in role management and cannot be changed or deleted. Other default roles can be adjusted or deleted if they are not assigned to users and are not configured as the default role for new users.
 
 Custom Roles
 ============

--- a/docs/application/administration/settings/content/projects.rst
+++ b/docs/application/administration/settings/content/projects.rst
@@ -11,6 +11,10 @@ If we want to let users select visibility of their projects within the |project_
 * **Visible - Comment** = the project is visible in comment mode to all logged-in users, i.e. all users will be able to see the project in their :ref:`projects list<project-list>`, access it and comment it (but not edit anything unless they are invited with different permissions).
 * **Visible - Edit** = the project is visible in edit mode to all logged-in users, i.e. all users will be able to see the project in their :ref:`projects list<project-list>`, access it, comment it, and also edit it (e.g. answer questions or editor notes).
 
+.. NOTE::
+
+    Project visibility controls access granted through the project itself. Users with global project permissions from their :ref:`role<roles>` may have access to projects independently of these visibility settings.
+
 
 Project Sharing
 ===============
@@ -21,6 +25,10 @@ If we want to let users select sharing option of their projects within the |proj
 * **View with the link** = anyone with the link to the project may open it in view mode and browse it.
 * **Comment with the link** = anyone with the link to the project may open it in comment mode, i.e. browse it and comment on questions.
 * **Edit with the link** = anyone with the link to the project may open it in edit mode, i.e. browse it, comment on questions, and also edit it (e.g. answer questions or editor notes).
+
+.. NOTE::
+
+    Project sharing settings control direct project collaboration and public-link access. They do not replace global project permissions configured in :ref:`roles<roles>`.
 
 
 Anonymous Projects

--- a/docs/application/administration/settings/index.rst
+++ b/docs/application/administration/settings/index.rst
@@ -3,7 +3,7 @@
 Settings
 ********
 
-This section covers different settings available to admin users. The settings are categorized as listed below.
+This section covers different settings available to users with permission to manage settings. The settings are categorized as listed below.
 
 .. NOTE::
     

--- a/docs/application/administration/settings/system/authentication.rst
+++ b/docs/application/administration/settings/system/authentication.rst
@@ -1,12 +1,18 @@
+.. _authentication:
+
 Authentication
 **************
 
-The **Default Role** settings option allows us to define which role is assigned to new users (see :ref:`user roles<user-roles>` for details about permissions).
+The **Default Role** settings option allows us to define which :ref:`role<roles>` is assigned to new users.
 
 
 .. WARNING::
     
-    It is recommended to set this to the lowest role possible, i.e. **Researchers**. Otherwise, new users will be able to change the content for all other users in the |project_name| instance.
+    It is recommended to set this to the lowest-privilege role that fits new users. Otherwise, new users may be able to change content or settings for other users in the |project_name| instance.
+
+.. NOTE::
+
+    A role configured as the default role for new users cannot be deleted.
 
 
 Internal

--- a/docs/application/administration/settings/user-interface/dashboard-and-login-screen.rst
+++ b/docs/application/administration/settings/user-interface/dashboard-and-login-screen.rst
@@ -1,30 +1,30 @@
 Dashboard & Login Screen
 ************************
 
-The dashboard settings allows us to adjust what users will see after they log in, i.e. on the application initial page called the dashboard. 
+Dashboard settings allow us to adjust what users will see after they log in, i.e. on the application initial page called the dashboard.
 
 Dashboard Style
 ===============
 
-We can select the **Dashboard Style** whether the user should see a standard **welcome** screen which just greets the user in the application, or a **role-based** dashboard which contains widgets based on current user's role (see :ref:`user-roles`):
+We can select the **Dashboard Style** to decide whether the user should see a standard **welcome** screen, or a **role-based** dashboard with widgets based on the current user's :ref:`role<roles>` and permissions:
 
-* **Researcher**
+* **Project work**
 
   * **Recent Projects Widget** contains a list of recent projects of the user for a quick navigation.
 
   * **Create Project Widget** lets the user quickly start a new project.
 
-* **Data Steward**
+* **Content management**
 
-  * **Create KM / Project Template Widgets** let the user to quickly start a new knowledge model editor or project template.
+  * **Create KM / Project Template Widgets** let the user quickly start a new knowledge model editor or project template.
 
-  * **Outdated KM / Document Templates Widgets** allow to quickly see outdated packages and document templates in case the DSW Registry connection is configured.
+  * **Outdated KM / Document Templates Widgets** allow the user to quickly see outdated packages and document templates when the DSW Registry connection is configured.
 
-  * **Import KM / Document Template Widgets** allow to proceed easily to import of a knowledge model or a document template in case the DSW Registry connection is configured.
+  * **Import KM / Document Template Widgets** make it easier to import a knowledge model or document template when the DSW Registry connection is configured.
 
-* **Administrator**
+* **Instance administration**
 
-  * **Outdated KM / Document Templates Widgets** allow to quickly see outdated packages and document templates in case the DSW Registry connection is configured.
+  * **Outdated KM / Document Templates Widgets** allow the user to quickly see outdated packages and document templates when the DSW Registry connection is configured.
 
   * **Usage Widget** summarizes the usage just as is also possible to see in the :doc:`../info/usage`.
 
@@ -32,9 +32,9 @@ We can select the **Dashboard Style** whether the user should see a standard **w
 
   * **Configure Look and Feel Widget** quickly navigates to :doc:`../user-interface/look-and-feel` to adjust style of the |project_name| instance.
 
-  * **Connect DSW Registry Widget** quickly navigates to :doc:`../content/dsw-registry` to configure the connection (if not yet been done).
+  * **Connect DSW Registry Widget** quickly navigates to :doc:`../content/dsw-registry` to configure the connection if it has not been configured yet.
 
-  * **Add OpenID Widget** quickly navigates to :doc:`../system/authentication` to configure the identity provider services (if not yet been done).
+  * **Add OpenID Widget** quickly navigates to :doc:`../system/authentication` to configure identity provider services if they have not been configured yet.
 
 
 .. _login-info:

--- a/docs/application/administration/users/create.rst
+++ b/docs/application/administration/users/create.rst
@@ -3,7 +3,7 @@
 Create User
 ***********
 
-As admins, we can create new users manually by clicking :guilabel:`Create` on the :ref:`users list<users-list>` and submitting the form. Each user must have a unique email address, first name and last name, assigned :ref:`role<user-roles>`, and a password. Optionally, a user can have affiliation specified.
+Users with permission to manage users can create new users manually by clicking :guilabel:`Create` on the :ref:`users list<users-list>` and submitting the form. Each user must have a unique email address, first name and last name, assigned :ref:`role<roles>`, and a password. Optionally, a user can have affiliation specified.
 
 .. figure:: create/create.png
     :width: 500
@@ -13,4 +13,4 @@ As admins, we can create new users manually by clicking :guilabel:`Create` on th
 
 .. NOTE::
 
-    If the user is created by administrator, the user is activated by default and no email is sent to the user.
+    If the user is created manually by a user manager, the user is activated by default and no email is sent to the user.

--- a/docs/application/administration/users/detail.rst
+++ b/docs/application/administration/users/detail.rst
@@ -3,7 +3,7 @@
 User Detail
 ***********
 
-As admins, we can edit existing users manually on the detail (selected user from  the :ref:`users list<users-list>`). It is possible to change all properties of the user, including possibility to change whether the user account is active or inactive. 
+Users with permission to manage users can edit existing users manually on the detail (selected user from the :ref:`users list<users-list>`). It is possible to change all properties of the user, including whether the user account is active or inactive.
 
 .. figure:: detail/profile.png
     
@@ -21,64 +21,8 @@ The password can be also changed (after selecting :guilabel:`Password` from the 
 User Roles
 ==========
 
-There are three user roles available: researchers, data steward, and admin. Permissions are associated with the roles, basically they affect what the users can do in a |project_name| instance:
+Each user has one global :ref:`role<roles>`. The role determines which parts of the |project_name| instance the user can access and what actions they can perform.
 
-.. raw:: html
+Default roles cover the common researcher, data steward, and admin workflows. Users with permission to manage settings can also create custom roles when they need a different combination of permissions.
 
-    <div class="table-wrapper docutils container">
-        <table class="docutils align-default">
-            <thead>
-                <tr>
-                    <th></th>
-                    <th>Researcher</th>
-                    <th>Data Steward</th>
-                    <th>Admin</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>Projects</td>
-                    <td class="text-center">✔</td>
-                    <td class="text-center">✔</td>
-                    <td class="text-center">✔ (all)</td>
-                </tr>
-                <tr>
-                    <td>Knowledge Models</td>
-                    <td class="text-center">✔ (read-only)</td>
-                    <td class="text-center">✔</td>
-                    <td class="text-center">✔</td>
-                </tr>
-                <tr>
-                    <td>Knowledge Models Editors</td>
-                    <td class="text-center"></td>
-                    <td class="text-center">✔</td>
-                    <td class="text-center">✔</td>
-                </tr>
-                <tr>
-                    <td>Document Templates</td>
-                    <td class="text-center"></td>
-                    <td class="text-center">✔</td>
-                    <td class="text-center">✔</td>
-                </tr>
-                <tr>
-                    <td>Settings</td>
-                    <td class="text-center"></td>
-                    <td class="text-center"></td>
-                    <td class="text-center">✔</td>
-                </tr>
-                <tr>
-                    <td>Locales</td>
-                    <td class="text-center"></td>
-                    <td class="text-center"></td>
-                    <td class="text-center">✔</td>
-                </tr>
-                <tr>
-                    <td>Users</td>
-                    <td class="text-center"></td>
-                    <td class="text-center"></td>
-                    <td class="text-center">✔</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-
+Changing the role of a user updates the permissions assigned to that user.

--- a/docs/application/administration/users/index.rst
+++ b/docs/application/administration/users/index.rst
@@ -3,9 +3,9 @@
 Users
 *****
 
-Users list allows admins to see and manage all users in a |project_name| instance. The list can be filtered using role, searched based using name or email fragment, and sorted via various properties of users. The list shows the role of a user next to its name and also indicates in case the user is inactive. Next to the email, we can quickly see what authentication services the user uses to log-in.
+Users list allows users with permission to manage users to see and manage all users in a |project_name| instance. The list can be filtered using :ref:`roles<roles>`, searched based using name or email fragment, and sorted via various properties of users. The list shows the role of a user next to its name and also indicates in case the user is inactive. Next to the email, we can quickly see what authentication services the user uses to log-in.
 
-A :ref:`user detail<user-detail>` can be opened by clicking the name of a user or by selecting :guilabel:`Edit` in the right dropdown menu for the desired row. There, a user can be also deleted via the :guilabel:`Delete` action. Finally, administrator can :ref:`create a new user<user-create>` by clicking :guilabel:`Create`.
+A :ref:`user detail<user-detail>` can be opened by clicking the name of a user or by selecting :guilabel:`Edit` in the right dropdown menu for the desired row. There, a user can be also deleted via the :guilabel:`Delete` action. Finally, a new user can be :ref:`created<user-create>` by clicking :guilabel:`Create`.
 
 .. figure:: index/list.png
     
@@ -24,4 +24,3 @@ A :ref:`user detail<user-detail>` can be opened by clicking the name of a user o
 
     Create<create>
     Detail<detail>
-

--- a/docs/application/document-templates/editors/index.rst
+++ b/docs/application/document-templates/editors/index.rst
@@ -3,7 +3,7 @@
 Document Template Editors
 *************************
 
-On this page, we can see a list of all document template editors. Everyone with the data steward role assigned can see all the document template editors and use them.
+On this page, users with permission to use document template editors can see all document template editors and use them.
 
 .. figure:: index/list.png
     

--- a/docs/application/document-templates/list/index.rst
+++ b/docs/application/document-templates/list/index.rst
@@ -1,7 +1,7 @@
 Document Template List
 **********************
 
-As **data stewards** and **admins**, we can check and manage all document templates from the list accessible from the main menu via :guilabel:`Document Templates`. The list can be filtered and sorted by name.
+Users with permission to manage document templates can check and manage all document templates from the list accessible from the main menu via :guilabel:`Document Templates`. The list can be filtered and sorted by name.
 
 For each document template, we can see the latest version present; however, we can see all the versions by accessing the :doc:`./detail` by clicking the name of the template or via :guilabel:`View detail` from the right dropdown item menu. The dropdown menu also offers :guilabel:`Export` of the latest document template or :guilabel:`Delete` of entire template (all its versions).
 

--- a/docs/application/knowledge-models/editors/index.rst
+++ b/docs/application/knowledge-models/editors/index.rst
@@ -3,7 +3,7 @@
 Knowledge Model Editors
 ***********************
 
-As admins and data stewards, we can see a list of all knowledge model editors.
+Users with permission to use knowledge model editors can see a list of all knowledge model editors.
 
 .. figure:: index/knowledge-model-editors-list.png
     
@@ -36,4 +36,3 @@ If there is an ongoing :ref:`knowledge model migration<knowledge-model-migration
     Create<create>
     Detail<detail/index>
     Migration<migration>
-    

--- a/docs/application/knowledge-models/list/detail.rst
+++ b/docs/application/knowledge-models/list/detail.rst
@@ -9,7 +9,7 @@ The main part of the detail is the README of the KM that should contain basic in
 
 In the top bar, we can :guilabel:`Export` the knowledge model as a KM file or :guilabel:`Delete` this version of the knowledge model (only if it is not already used for some projects or other KMs and editors).
 
-In the top pane, we can see the options based on our role:
+In the top pane, we can see the options based on our permissions:
 
 - :guilabel:`Preview` can be used to check the content of the KM via the :doc:`./preview` feature.
 - :guilabel:`Export` for exporting the latest version of the KM as a file.
@@ -17,7 +17,7 @@ In the top pane, we can see the options based on our role:
 - :guilabel:`Create KM editor` is a shortcut for :doc:`../editors/create` for creating a new version.
 - :guilabel:`Fork KM` is again a shortcut for :doc:`../editors/create` for to create a fork (some more specific KM based on this one).
 - :guilabel:`Create project` is a shortcut to :doc:`../../projects/list/create` with this KM.
-- :guilabel:`Set deprecated` or :guilabel:`Restore` for setting a KM deprecated when we no longer want the **researchers** to use it.
+- :guilabel:`Set deprecated` or :guilabel:`Restore` for setting a KM deprecated when we no longer want users to use it for new projects.
 - :guilabel:`Set public` or :guilabel:`Set private` for changing the visibility of the KM. Public KM can be viewed by non-logged in users.
 - :guilabel:`Delete` the specific version of the KM (possible only if is not used in any projects or linked in other KMs and editors, cannot be undone).
 

--- a/docs/application/knowledge-models/list/index.rst
+++ b/docs/application/knowledge-models/list/index.rst
@@ -3,7 +3,7 @@
 Knowledge Model List
 ********************
 
-As **data stewards** and **admins**, we can manage the knowledge models that are in our |project_name|. We can access the list of knowledge model from the main menu via :guilabel:`Knowledge Model`. The list can be filtered and sorted by name or creation date. We can also search for a specific knowledge model by its id, name or version. The list shows the name, version, id, author, description and last update.
+Users with permission to manage knowledge models can manage the knowledge models that are in our |project_name|. We can access the list of knowledge model from the main menu via :guilabel:`Knowledge Model`. The list can be filtered and sorted by name or creation date. We can also search for a specific knowledge model by its id, name or version. The list shows the name, version, id, author, description and last update.
 
 For each knowledge model (KM), we can see the latest version in the list. If we want to read more about a specific KM or see the older versions, we need to access the :doc:`./detail` by clicking the name of KM or clicking :guilabel:`Open` from the right item menu (three dots). There are also other options for each item:
 
@@ -14,7 +14,7 @@ For each knowledge model (KM), we can see the latest version in the list. If we 
 - :guilabel:`Create KM editor` is a shortcut for :doc:`../editors/create` for creating a new version.
 - :guilabel:`Fork KM` is again a shortcut for :doc:`../editors/create` for to create a fork (some more specific KM based on this one).
 - :guilabel:`Create project` is a shortcut to :doc:`../../projects/list/create` with this KM.
-- :guilabel:`Set deprecated` or :guilabel:`Restore` for setting a KM deprecated when we no longer want the **researchers** to use it.
+- :guilabel:`Set deprecated` or :guilabel:`Restore` for setting a KM deprecated when we no longer want users to use it for new projects.
 - :guilabel:`Set public` or :guilabel:`Set private` for changing the visibility of the KM. Public KM can be viewed by non-logged in users.
 - :guilabel:`Delete` for all versions of the KM. (Single version can be deleted from the KM's :doc:`./detail` page).
 
@@ -34,7 +34,7 @@ Finally, there is an option to :doc:`./import` by clicking the :guilabel:`Import
     You can import multiple knowledge models from file at once.
 
 
-For **data stewards** and **admins**, :guilabel:`update available` badge may appear if there is a newer version of the knowledge model in the `DSW Registry <https://registry.ds-wizard.org>`__ (and if configured).
+For users with permission to manage knowledge models, :guilabel:`update available` badge may appear if there is a newer version of the knowledge model in the `DSW Registry <https://registry.ds-wizard.org>`__ (and if configured).
 
 Finally, there is an option to :doc:`./import` by click the :guilabel:`Import` button in the top right part of the screen.
 
@@ -59,4 +59,3 @@ Finally, there is an option to :doc:`./import` by click the :guilabel:`Import` b
     Detail<detail>
     Preview<preview>
     Compare<compare>
-    

--- a/docs/application/knowledge-models/list/preview.rst
+++ b/docs/application/knowledge-models/list/preview.rst
@@ -9,6 +9,6 @@ The preview feature for knowledge models allows us to check the content, i.e. ho
 
     https://researchers.ds-wizard.org/knowledge-models/dsw:root:2.4.4/preview?questionUuid=0b12fb8c-ee0f-40c0-9c53-b6826b786a0c
 
-For a nested question, all needed question above in the tree will be automatically prefilled. The KM preview may be also available to non-logged-in users, if configured by admins.
+For a nested question, all needed question above in the tree will be automatically prefilled. The KM preview may be also available to non-logged-in users, if configured by users with permission to manage settings.
 
-A user can directly create a new project from the KM preview. Again, this can be available also for non-logged-in users if anonymous projects are enabled by administrations in :doc:`../../administration/settings/content/projects`.
+A user can directly create a new project from the KM preview. Again, this can be available also for non-logged-in users if anonymous projects are enabled in :doc:`../../administration/settings/content/projects`.

--- a/docs/application/profile/settings/submission-settings.rst
+++ b/docs/application/profile/settings/submission-settings.rst
@@ -9,5 +9,4 @@ If there is no submission service that requires additional properties, there is 
 
 .. NOTE::
 
-    The admin should notify users about the required properties for the submission service.
-
+    The person responsible for submission service settings should notify users about the required properties for the submission service.

--- a/docs/application/projects/documents.rst
+++ b/docs/application/projects/documents.rst
@@ -1,7 +1,7 @@
 Documents
 *********
 
-As admins, we can quickly browse all documents stored in the |project_name| instance by navigating to :guilabel:`Documents` from the projects menu. It is possible to search for a document by name or sort them using their name or creation timestamp.
+Users with permission to manage all projects can quickly browse all documents stored in the |project_name| instance by navigating to :guilabel:`Documents` from the projects menu. It is possible to search for a document by name or sort them using their name or creation timestamp.
 
 Each document has a name, format, specific size (if the generation is completed), a link to the project it was generated from, and a template used for its creation. The document can be directly downloaded or deleted from the list. 
 
@@ -10,4 +10,3 @@ In case that there is a document that was not generated due to an error, we can 
 .. figure:: documents/documents.png
     
     List of all documents across projects.
-

--- a/docs/application/projects/files.rst
+++ b/docs/application/projects/files.rst
@@ -1,16 +1,15 @@
 Files
 *****
 
-As admins, we can quickly browse all files stored in the |project_name| instance by navigating to :guilabel:`Files` from the projects menu. It is possible to search for a file by name or sort them using their creation timestamp, name or size.
+Users with permission to manage all projects can quickly browse all files stored in the |project_name| instance by navigating to :guilabel:`Files` from the projects menu. It is possible to search for a file by name or sort them using their creation timestamp, name or size.
 
 Each file has a name, size, a link to the project it was uploaded to and user who uploaded it. The file can be directly downloaded or deleted from the list. 
 
 .. WARNING::
 
-    It is not recommended to delete files from the list without informing the project team, as it can lead to confusion among researchers. Admins should always communicate with the project team before deleting files.
+    It is not recommended to delete files from the list without informing the project team, as it can lead to confusion among users. Users with permission to manage all projects should always communicate with the project team before deleting files.
 
 
 .. figure:: files/files.png
     
     List of all files across projects.
-

--- a/docs/application/projects/list/create.rst
+++ b/docs/application/projects/list/create.rst
@@ -7,7 +7,7 @@ We can create a new project by navigating to :guilabel:`Projects` in the main me
 
 .. NOTE::
 
-    If we have **Researcher** role we also have a **Create Project** widget on our dashboard right after logging in. We can click on :guilabel:`Create` button there, too.
+    Depending on our :ref:`role<roles>` and dashboard settings, we may also have a **Create Project** widget on our dashboard right after logging in. We can click on :guilabel:`Create` button there, too.
 
 
 Based on our instance configuration, we can create the new project from a project template, custom, or both.
@@ -24,7 +24,7 @@ Based on our instance configuration, we can create the new project from a projec
 From Project Template
 =====================
 
-There are many options how to create and configure a project, such as what :ref:`knowledge model<knowledge-model>` or :ref:`document template<document-template>` to use. :ref:`Project templates<project-templates>` are prepared projects by data stewards with possibly pre-selected knowledge models and document templates, they can have some pre-filled answers, comments and TODOs as well.
+There are many options how to create and configure a project, such as what :ref:`knowledge model<knowledge-model>` or :ref:`document template<document-template>` to use. :ref:`Project templates<project-templates>` are prepared projects with possibly pre-selected knowledge models and document templates, they can have some pre-filled answers, comments and TODOs as well.
 
 So if there are any project templates created in our instance, we can use them to have a smoother start of our project. We just need to give our project a **name** and choose the **project template** from offered options.
 

--- a/docs/application/projects/list/detail/questionnaire.rst
+++ b/docs/application/projects/list/detail/questionnaire.rst
@@ -65,7 +65,7 @@ Some additional information can also be part of the question:
 - **List of references** - links to additional external resources related to the question
 - **List of experts** - whom to contact when help is needed with answering the question
 
-Based on our role in the project and specific instance settings there are some additional actions besides answering the question:
+Based on our project sharing role, global permissions, and specific instance settings there are some additional actions besides answering the question:
 
 - :ref:`Add TODO<todos>`
 - :ref:`Add comment<add-comment>`

--- a/docs/application/projects/list/detail/settings.rst
+++ b/docs/application/projects/list/detail/settings.rst
@@ -28,14 +28,14 @@ We can set a **default document template** and a **default document format**. Th
 Project Template
 ================
 
-We can use the project as a :ref:`project template<project-templates>`. If we enable this option, researchers can use it when creating a new project :ref:`from project template<from-project-template>`. Note that we also need to make it visible for other logged-in users in :ref:`sharing<sharing>` settings.
+We can use the project as a :ref:`project template<project-templates>`. If we enable this option, users can use it when creating a new project :ref:`from project template<from-project-template>`. Note that we also need to make it visible for other logged-in users in :ref:`sharing<sharing>` settings.
 
 .. NOTE::
 
-    Project template options are visible only for Data Stewards or Admins.
+    Project template options are visible only for users with permission to manage project templates.
 
 
-:guilabel:`Unsupported metamodel` badge can appear, when the document template is not compatible with the version of |project_name|. Researchers should contact their Data Steward or Administrator in this case.
+:guilabel:`Unsupported metamodel` badge can appear, when the document template is not compatible with the version of |project_name|. Users should contact the person responsible for document templates or instance administration in this case.
 
 Knowledge Model
 ===============

--- a/docs/application/projects/list/detail/sharing.rst
+++ b/docs/application/projects/list/detail/sharing.rst
@@ -3,7 +3,7 @@
 Sharing
 *******
 
-We can share project with other |project_name| users or even external collaborators. We can access all the sharing option by clicking the :guilabel:`Share` button in the top right.
+We can share a project with other |project_name| users or external collaborators. We can access all sharing options by clicking the :guilabel:`Share` button in the top right.
 
 .. figure:: sharing/share-modal.png
     :width: 540
@@ -13,7 +13,7 @@ We can share project with other |project_name| users or even external collaborat
 
 .. NOTE::
 
-    It is not possible to remove last project owner. To change the project owner, we need to add another user as an owner first.
+    It is not possible to remove the last project owner. To change the project owner, we need to add another user as an owner first.
 
 
 If we want to only see how Sharing is set up or copy the project link, we can use the arrow button which is a part of the :guilabel:`Share` button.
@@ -26,10 +26,14 @@ If we want to only see how Sharing is set up or copy the project link, we can us
 
 .. NOTE::
 
-    When the sharing settings is changed, the changes are saved automatically.
+    When sharing settings are changed, the changes are saved automatically.
 
 
-There are different roles how we can share the project that can access different project features:
+There are different project sharing roles that grant access to different project features:
+
+.. NOTE::
+
+    These are project sharing roles. They apply to this specific project and are separate from global :ref:`roles<roles>`. A global role can also grant access to all projects, depending on its permissions.
 
 
 .. raw:: html
@@ -150,7 +154,7 @@ The following video tutorial explains and showcases sharing options and tools th
 Users
 =====
 
-We can choose specific users from the |project_name| instance and their role on the project to grant them access to project features based on the table above. This is a good way to add other collaborators that work together with us on the project. Also, this is the only way to add other project owners.
+We can choose specific users from the |project_name| instance and their project sharing role to grant them access to project features based on the table above. This is a good way to add other collaborators that work together with us on the project. Also, this is the only way to add other project owners.
 
 
 Visible by all other logged-in users

--- a/docs/application/projects/list/index.rst
+++ b/docs/application/projects/list/index.rst
@@ -3,7 +3,7 @@
 Project List
 ************
 
-In the project list, we can see a list of all projects we have access to. Those are the projects where we were assigned to with any role or that are visible by all other logged-in users in the :ref:`project sharing settings<sharing>`. The projects are filtered to those we are explicitly assigned to by default.
+In the project list, we can see a list of all projects we have access to. Those are the projects where we were assigned with a project sharing role, projects that are visible to all logged-in users in the :ref:`project sharing settings<sharing>`, or projects available through our global :ref:`role<roles>` permissions. The projects are filtered to those we are explicitly assigned to by default.
 
 We can see projects name, label :guilabel:`Template` if the project is a template, and icon indicating sharing settings:
 
@@ -25,7 +25,7 @@ We can search for specific projects using the search field or filter them using 
 
 .. NOTE::
 
-    Note that some of the filters can be disabled based on the |project_name| instance settings or user role.
+    Note that some of the filters can be disabled based on the |project_name| instance settings or user permissions.
 
 
 We can :ref:`create a new project<create-project>` by clicking the :guilabel:`Create` button.

--- a/docs/application/projects/list/templates.rst
+++ b/docs/application/projects/list/templates.rst
@@ -5,11 +5,11 @@ Project Templates
 
 .. NOTE::
 
-    Only the data stewards or admins can create project templates.
+    Project templates can be created by users with permission to manage project templates.
 
 When creating a new project, we need to choose a knowledge model and optionally select some question tags. After the project is created, we should also choose a :ref:`default document template<default-document-template>` and format to enable :ref:`preview<preview>`. It can be overwhelming for new researchers to set up everything when they are new to all this.
 
-Project templates are special type of projects where we can set up everything -- choose a knowledge model and question tags, set up default document template, pre-fill some answers, add TODOs, comments or editor notes. Researchers can then pick from these project templates when :ref:`creating a new project<create-project>`. The new project will be the exact copy of the project template so they don't have to set those things themselves and they have an easier start to their data management planning.
+Project templates are special type of projects where we can set up everything -- choose a knowledge model and question tags, set up default document template, pre-fill some answers, add TODOs, comments or editor notes. Users can then pick from these project templates when :ref:`creating a new project<create-project>`. The new project will be the exact copy of the project template so they don't have to set those things themselves and they have an easier start to their data management planning.
 
 When we want to turn a project into a project template we need to go to the :ref:`project settings<project-settings>` and check the :guilabel:`Project Template` checkbox.
 

--- a/docs/more/development/api.rst
+++ b/docs/more/development/api.rst
@@ -15,7 +15,7 @@ DSW utilizes JSON Web Tokens (JWT) for both authentication and authorization, en
 * **OpenID Identity Provider** (for our client only): This method involves a more complex OpenID/OAuth flow, utilizing redirects with the ``/auth/{id}/`` endpoints to authenticate.
 * **API Keys**:  You can generate an API key in your user profile, which remains valid until its specified expiration date.
 
-While several public endpoints are accessible without authentication, most endpoints require it. The system will check if you are authorized to perform specific operations based on your :ref:`roles<user-roles>` and their permissions. These roles are defined globally and can also be specific to projects. This ensures that only authorized users can access and manipulate with sensitive resources.
+While several public endpoints are accessible without authentication, most endpoints require it. The system will check if you are authorized to perform specific operations based on your global :ref:`role<roles>` and project sharing permissions. This ensures that only authorized users can access and manipulate with sensitive resources.
 
 Example
 =======

--- a/docs/more/development/submission-service.rst
+++ b/docs/more/development/submission-service.rst
@@ -3,7 +3,7 @@
 Submission Service
 ******************
 
-As admins, we can configure submission services using :doc:`../../application/administration/settings/content/document-submission`. The configured HTTP request is then used when a user clicks :guilabel:`Submit` for an allowed document for submission and selected the desired submission service. The document is sent as a body of the request (or as multipart, based on the configuration) to the external service that should process it and return HTTP response with status code, and possibly also the `Location` header and some textual message.
+Users with permission to manage settings can configure submission services using :doc:`../../application/administration/settings/content/document-submission`. The configured HTTP request is then used when a user clicks :guilabel:`Submit` for an allowed document for submission and selected the desired submission service. The document is sent as a body of the request (or as multipart, based on the configuration) to the external service that should process it and return HTTP response with status code, and possibly also the `Location` header and some textual message.
 
 Usually, we will need a simple proxy service to be developed that will accommodate this to API of some information system, database, storage, or other service. For example, such a proxy service will be able to receive the JSON documents from |project_name|, retrieve additional information through |project_name| API as needed, transform it to some other resulting artifact and store it in some local database that is used by other systems.
 

--- a/docs/more/self-hosted-dsw/configuration/index.rst
+++ b/docs/more/self-hosted-dsw/configuration/index.rst
@@ -5,7 +5,7 @@ This section explains how to configure |project_name| instance on your own.
 
 .. _config-settings:
 
-Most of the configuration is done through :ref:`Settings<settings>` (accessible by Administrator).
+Most of the configuration is done through :ref:`Settings<settings>` (accessible to users with permission to manage settings).
 
 
 
@@ -21,5 +21,4 @@ Most of the configuration is done through :ref:`Settings<settings>` (accessible 
     document-templates
     email-templates
     plugins
-    
-    
+

--- a/docs/more/self-hosted-dsw/faq-notes.rst
+++ b/docs/more/self-hosted-dsw/faq-notes.rst
@@ -69,7 +69,7 @@ To connect to the DSW Registry and import new templates from there, you can foll
 
 .. NOTE::
 
-    The Sign up to the DSW Registry must be done by an admin. Once the admin signs up, data stewards can import and update templates from the DSW Registry.
+    The Sign up to the DSW Registry must be done by a user with permission to manage settings. Once the registry is connected, users with the relevant content permissions can import and update templates from the DSW Registry.
 
 
 Templates imported this way will have the :guilabel:`Update Available` badge when a new version is available in the Registry.

--- a/docs/more/self-hosted-dsw/upgrade-guidelines.rst
+++ b/docs/more/self-hosted-dsw/upgrade-guidelines.rst
@@ -48,7 +48,7 @@ Usually, nothing special is required for the upgrade. Internal structure changes
 4.31.X to 4.32.X
 ----------------
 
-*(nothing)*
+- Review migrated roles after the upgrade. Check which permissions each role has, confirm the default role for new users, and verify any organization-specific access expectations such as project support, user management, analytics, or content management.
 
 4.30.X to 4.31.X
 ----------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -66,6 +66,6 @@ tinycss2==1.5.1
 typing_extensions==4.16.0
 urllib3==2.7.0
 uvicorn==0.34.3
-watchfiles==1.0.5
+watchfiles==1.2.0
 webencodings==0.5.1
 websockets==15.0.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 accessible-pygments==0.0.5
 alabaster==1.0.0
+anyio==4.9.0
 apeye==1.4.1
 apeye-core==1.1.5
 autodocsumm==0.2.15
@@ -9,11 +10,14 @@ beautifulsoup4==4.15.0
 CacheControl==0.14.4
 certifi==2026.7.22
 charset-normalizer==3.4.9
+click==8.2.1
+colorama==0.4.6
 dict2css==0.6.0
 docutils==0.22.4
 domdf_python_tools==3.10.0
 filelock==3.32.2
 furo==2025.12.19
+h11==0.16.0
 html5lib==1.1
 idna==3.18
 imagesize==2.0.0
@@ -34,9 +38,11 @@ roman==5.2
 roman-numerals==4.1.0
 ruamel.yaml==0.19.1
 six==1.17.0
+sniffio==1.3.1
 snowballstemmer==3.1.1
 soupsieve==2.9.1
 Sphinx==9.1.0
+sphinx-autobuild==2024.10.3
 sphinx-autodoc-typehints==3.5.2
 sphinx-basic-ng==1.0.0b2
 sphinx-jinja2-compat==0.4.1
@@ -53,9 +59,13 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
 sphinxcontrib-youtube==1.5.0
+starlette==0.46.2
 standard-imghdr==3.10.14
 tabulate==0.10.0
 tinycss2==1.5.1
 typing_extensions==4.16.0
 urllib3==2.7.0
+uvicorn==0.34.3
+watchfiles==1.0.5
 webencodings==0.5.1
+websockets==15.0.1


### PR DESCRIPTION
## Summary
- add a public Administration > Roles page for configurable global roles, default roles, custom roles, and permission groups
- update users, authentication, dashboard, project access, content management, and self-hosted docs to use permission-based wording instead of fixed role assumptions
- clarify that project sharing roles are separate from global roles and keep the existing project sharing options/table unchanged
- add TODO screenshot placeholders for roles list, role create/edit form, and non-deletable role state

## Verification
- make html
- git diff --check
- scanned public docs for internal permission names from the source document
- scanned for outdated fixed-role wording