### PR TITLE
Audit facts

### DIFF
--- a/docs/about/introduction/knowledge-model.rst
+++ b/docs/about/introduction/knowledge-model.rst
@@ -156,14 +156,14 @@ Validation is used to define some rules for the answers in Value question type. 
 Reference
 ---------
 
-References are used to provide additional information for :ref:`questions<question>`. There are three types of references. :ref:`Resource page reference<resource-page>`, :ref:`URL reference<url-reference>`, and :ref:`Cross reference<cross-reference>`. resource page references are gathered in the resource collections.
+References are used to provide additional information for :ref:`questions<question>`. There are three types of references. :ref:`Resource page reference<resource-page>`, :ref:`URL reference<url-reference>`, and :ref:`Cross reference<cross-reference>`. Resource page references are gathered in the resource collections.
 
 .. _resource-collection:
 
 Resource Collection
 ^^^^^^^^^^^^^^^^^^^
 
-Resource collections are used to group together :ref:`resource pages<resource-page>` that are related to each other. Each resource collection has a **title** and has a list of resource pages. Resource collection is created on a level of a Knowledge Model.
+Resource collections are used to group together :ref:`resource pages<resource-page>` that are related to each other. Each resource collection has a **title** and has a list of resource pages. Resource collection is created on a level of a knowledge model.
 
 .. _resource-page:
 

--- a/docs/about/introduction/knowledge-model.rst
+++ b/docs/about/introduction/knowledge-model.rst
@@ -9,7 +9,7 @@ While all the possibilities are defined in the knowledge model, when researchers
 
 Knowledge models are created by data stewards in the :ref:`knowledge model editor<knowledge-model-editor>`.
 
-Each knowledge model also has a source language. A published knowledge model version can have additional :ref:`translations<knowledge-model-translations>` so the same questionnaire structure can be shown in different languages. These translations cover texts that are part of the knowledge model, such as question titles, descriptions, answer labels, advice, and resource pages. They do not translate answers typed by users.
+Each knowledge model also has a source language. A published knowledge model version can have additional :ref:`locales<knowledge-model-locales>` so the same questionnaire structure can be shown in different languages. These locales cover texts that are part of the knowledge model, such as question titles, descriptions, answer labels, advice, and resource pages. They do not translate answers typed by users.
 
 Knowledge Model Structure
 =========================

--- a/docs/about/introduction/knowledge-model.rst
+++ b/docs/about/introduction/knowledge-model.rst
@@ -9,6 +9,8 @@ While all the possibilities are defined in the knowledge model, when researchers
 
 Knowledge models are created by data stewards in the :ref:`knowledge model editor<knowledge-model-editor>`.
 
+Each knowledge model also has a source language. A published knowledge model version can have additional :ref:`translations<knowledge-model-translations>` so the same questionnaire structure can be shown in different languages. These translations cover texts that are part of the knowledge model, such as question titles, descriptions, answer labels, advice, and resource pages. They do not translate answers typed by users.
+
 Knowledge Model Structure
 =========================
 

--- a/docs/about/introduction/knowledge-model.rst
+++ b/docs/about/introduction/knowledge-model.rst
@@ -9,8 +9,6 @@ While all the possibilities are defined in the knowledge model, when researchers
 
 Knowledge models are created by data stewards in the :ref:`knowledge model editor<knowledge-model-editor>`.
 
-Each knowledge model also has a source language. A published knowledge model version can have additional :ref:`translations<knowledge-model-translations>` so the same questionnaire structure can be shown in different languages. These translations cover texts that are part of the knowledge model, such as question titles, descriptions, answer labels, advice, and resource pages. They do not translate answers typed by users.
-
 Knowledge Model Structure
 =========================
 

--- a/docs/application/administration/locales/import.rst
+++ b/docs/application/administration/locales/import.rst
@@ -3,7 +3,7 @@
 Import Locale
 *************
 
-We can import an existing locale by navigating to :menuselection:`Settings → Locales` in the main menu and then clicking on :guilabel:`Import` button on the list of locales.
+We can import an existing locale by navigating to :menuselection:`Administration → Locales` in the main menu and then clicking on :guilabel:`Import` button on the list of locales.
 
 
 .. _locale-import-from-registry:
@@ -34,4 +34,3 @@ We can import a locale as a ZIP package. Such a package can be created as an exp
     :width: 500
     
     Input for importing a locale using a ZIP package.
-

--- a/docs/application/administration/locales/index.rst
+++ b/docs/application/administration/locales/index.rst
@@ -5,8 +5,6 @@ After navigating to :guilabel:`Locales` (under :guilabel:`Administration`), we c
 
 The DSW UI and emails can be localized to different languages. The preferred language is determined by the user's browser settings or by the user's profile settings.
 
-These locales are used for the DSW user interface and emails. They are separate from :ref:`knowledge model translations<knowledge-model-translations>`, which translate questionnaire content provided by a knowledge model.
-
 .. NOTE::
 
     Locales can be used not only for translations but also for customizing the DSW to a specific domain.

--- a/docs/application/administration/locales/index.rst
+++ b/docs/application/administration/locales/index.rst
@@ -5,7 +5,7 @@ After navigating to :guilabel:`Locales` (under :guilabel:`Administration`), we c
 
 The DSW UI and emails can be localized to different languages. The preferred language is determined by the user's browser settings or by the user's profile settings.
 
-These locales are used for the DSW user interface and emails. They are separate from :ref:`knowledge model translations<knowledge-model-translations>`, which translate questionnaire content provided by a knowledge model.
+These locales are used for the DSW user interface and emails. They are separate from :ref:`knowledge model locales<knowledge-model-locales>`, which translate questionnaire content provided by a knowledge model.
 
 .. NOTE::
 

--- a/docs/application/administration/locales/index.rst
+++ b/docs/application/administration/locales/index.rst
@@ -5,6 +5,8 @@ After navigating to :guilabel:`Locales` (under :guilabel:`Administration`), we c
 
 The DSW UI and emails can be localized to different languages. The preferred language is determined by the user's browser settings or by the user's profile settings.
 
+These locales are used for the DSW user interface and emails. They are separate from :ref:`knowledge model translations<knowledge-model-translations>`, which translate questionnaire content provided by a knowledge model.
+
 .. NOTE::
 
     Locales can be used not only for translations but also for customizing the DSW to a specific domain.

--- a/docs/application/administration/roles/index.rst
+++ b/docs/application/administration/roles/index.rst
@@ -19,7 +19,7 @@ The **Admin** role cannot be changed or deleted. Other default roles can be adju
 Custom Roles
 ============
 
-Users with permission to manage settings can create custom roles when the default roles do not match the way an organization works. A role has a name, an optional description, and selected permissions.
+Users with permission to manage settings can create custom roles when the default roles do not match the way an organization works. A role has a name and selected permissions.
 
 Custom roles are useful for cases such as:
 
@@ -38,7 +38,7 @@ Permissions are grouped by the type of work they enable.
 
 Project-related permissions can allow a role to:
 
-- manage project templates
+- manage project templates and create projects directly from knowledge models when project creation is restricted to templates
 - view all projects
 - comment on all projects
 - edit all projects
@@ -50,6 +50,8 @@ Content-related permissions can allow a role to:
 - manage knowledge models, including knowledge model secrets
 - create and use document template editors, including publishing
 - manage document templates
+
+The editor permissions require the corresponding management permissions. When we enable **Use Knowledge Model Editor**, the role also needs **Manage Knowledge Models**. When we enable **Use Document Template Editor**, the role also needs **Manage Document Templates**.
 
 Administration permissions can allow a role to:
 

--- a/docs/application/administration/roles/index.rst
+++ b/docs/application/administration/roles/index.rst
@@ -25,7 +25,6 @@ Custom roles are useful for cases such as:
 
 - a data support role that can view or comment on all projects
 - a user-management role that can manage users without managing settings
-- an analytics role that can access reporting without broader administration access
 - a content-management role that can work with knowledge models or document templates
 
 .. TODO::
@@ -35,7 +34,7 @@ Custom roles are useful for cases such as:
 Role Permissions
 ================
 
-Permissions are grouped by the type of work they enable. The available groups depend on the DSW edition and enabled features.
+Permissions are grouped by the type of work they enable.
 
 Project-related permissions can allow a role to:
 
@@ -47,21 +46,15 @@ Project-related permissions can allow a role to:
 
 Content-related permissions can allow a role to:
 
-- create and use knowledge model editors
-- manage knowledge models
-- manage knowledge model secrets
-- create and use document template editors
+- create and use knowledge model editors, including migration and publishing
+- manage knowledge models, including knowledge model secrets
+- create and use document template editors, including publishing
 - manage document templates
-- manage locales
 
 Administration permissions can allow a role to:
 
 - manage users
 - manage settings
-- manage automations
-- access audit log
-- access integration hub
-- access analytics
 
 .. TODO::
 

--- a/docs/application/administration/settings/content/dsw-registry.rst
+++ b/docs/application/administration/settings/content/dsw-registry.rst
@@ -3,11 +3,11 @@
 DSW Registry
 ************
 
-In these settings, we can configure a connection to DSW Registry that will allow importing various content (Knowledge Models, Document Templates, and Locales) to our DSW instance.
+In these settings, we can configure a connection to DSW Registry that will allow importing various content (knowledge models, document templates, and locales) to our DSW instance.
 
 Upon enabling the DSW Registry option, we are prompted to enter a **Token**. It can be obtained either by direct registration in the `DSW Registry <https://registry.ds-wizard.org>`__ or by clicking the :guilabel:`Sign up` button. After clicking the button, we will need to enter details about the organization (prefilled from :doc:`../system/organization`) and the email address to which the confirmation will be sent (prefilled with the email of the current user). Then, after clicking a link in the confirmation email, the token will be prefilled automatically. After the token has been filled in either way, we can :guilabel:`Save` the settings.
 
-After successfully setting the DSW Registry, we will see the option to import from it for :ref:`Knowledge Models<km-import>`, :ref:`Document Templates<doc-template-import>`, and :ref:`Locales<locale-import>`.
+After successfully setting the DSW Registry, we will see the option to import from it for :ref:`knowledge models<km-import>`, :ref:`document templates<doc-template-import>`, and :ref:`locales<locale-import>`.
 
 .. NOTE::
 

--- a/docs/application/administration/settings/content/index.rst
+++ b/docs/application/administration/settings/content/index.rst
@@ -1,7 +1,7 @@
 Content Settings
 ****************
 
-This part of settings allows us to configure various content-related things such as the connection with DSW Registry for easy imports, Knowledge Models, Projects, and Document Submissions as listed below.
+This part of settings allows us to configure various content-related things such as the connection with DSW Registry for easy imports, knowledge models, projects, and document submissions as listed below.
 
 ----
 

--- a/docs/application/administration/settings/content/projects.rst
+++ b/docs/application/administration/settings/content/projects.rst
@@ -53,6 +53,12 @@ We can turn **Summary Report** on or off. It is a feature that allows users to g
 The **Summary Report** shows how many questions are answered and unanswered in each chapter. It can either count all questions in the Knowledge Model or only the questions required for the project’s current phase. Questions from later phases are ignored in the phase-based view. If a parent question is unanswered, its child questions are not counted separately. Chapter results are combined into the total **Summary Report**.
 
 
+Feedback
+========
+
+If enabled, users can submit feedback for questions to a configured GitHub repository. The configuration includes the **GitHub Repository Owner**, **GitHub Repository Name**, and **Access Token**.
+
+
 Project Tagging
 ===============
 

--- a/docs/application/administration/settings/content/projects.rst
+++ b/docs/application/administration/settings/content/projects.rst
@@ -34,7 +34,7 @@ If we want to let users select sharing options for their projects within the DSW
 Anonymous Projects
 ==================
 
-If we have set Knowledge Model as Public, we can also allow anonymous users to create projects where they will be able to fill questionnaires by enabling **Anonymous Projects**. These anonymous projects then work as any other projects with public link set to edit permissions. However, if a logged-in user accesses such a project, then they may claim the ownership by clicking the :guilabel:`Add to my projects` button. Anonymous users cannot create new documents; for that, they must register and open the project as a logged-in user.
+If we have set a knowledge model as public, we can also allow anonymous users to create projects where they will be able to fill questionnaires by enabling **Anonymous Projects**. These anonymous projects then work as any other projects with public link set to edit permissions. However, if a logged-in user accesses such a project, then they may claim the ownership by clicking the :guilabel:`Add to my projects` button. Anonymous users cannot create new documents; for that, they must register and open the project as a logged-in user.
 
 
 Project Creation
@@ -50,7 +50,7 @@ Summary Report
 
 We can turn **Summary Report** on or off. It is a feature that allows users to generate and see a **Summary Report** in their projects.
 
-The **Summary Report** shows how many questions are answered and unanswered in each chapter. It can either count all questions in the Knowledge Model or only the questions required for the project’s current phase. Questions from later phases are ignored in the phase-based view. If a parent question is unanswered, its child questions are not counted separately. Chapter results are combined into the total **Summary Report**.
+The **Summary Report** shows how many questions are answered and unanswered in each chapter. It can either count all questions in the knowledge model or only the questions required for the project’s current phase. Questions from later phases are ignored in the phase-based view. If a parent question is unanswered, its child questions are not counted separately. Chapter results are combined into the total **Summary Report**.
 
 
 Feedback

--- a/docs/application/document-templates/index.rst
+++ b/docs/application/document-templates/index.rst
@@ -3,7 +3,7 @@
 Document Templates
 ******************
 
-This section is about managing the document templates and document template editors. Similarly to Knowledge Models, we can manage :doc:`./list/index` or work on new or customize existing templates using :doc:`./editors/index`.
+This section is about managing the document templates and document template editors. Similarly to knowledge models, we can manage :doc:`./list/index` or work on new or customize existing templates using :doc:`./editors/index`.
 
 ----
 

--- a/docs/application/knowledge-models/editors/create.rst
+++ b/docs/application/knowledge-models/editors/create.rst
@@ -11,12 +11,12 @@ We can create a new knowledge model editor by navigating to :menuselection:`Know
     Form for creating a new knowledge model.
 
 
-Every knowledge model needs to have a **name**, a **knowledge model ID**, **version**, and **language**. The name should be something descriptive to help users understand what the knowledge model is about. The language is the source language of the knowledge model content. The knowledge model ID is used for the identification together with the :ref:`organization ID<organization-settings>` and knowledge model version after it is published. So the identifier of the knowledge model is:
+Every knowledge model needs to have a **name**, a **knowledge model ID** and **version**. The name should be something descriptive to help users understand what the knowledge model is about. The knowledge model ID is used for the identification together with the :ref:`organization ID<organization-settings>` and knowledge model version after it is published. So the identifier of the knowledge model is: 
 
 .. code::
 
     <organizationId>:<knowledgeModelId>:<version>
 
-We can create a new knowledge model editor either from scratch, i.e. the new knowledge model will be empty and we will build it all ourselves, or based on an existing knowledge model, which means that everything from the chosen knowledge model will be copied to ours. We can start from there and add, delete, or modify the existing entities in there. We just need to choose the original knowledge model in the **Based on** field. Alternatively, we can open the :ref:`knowledge model detail<km-detail>` and click on :guilabel:`Fork KM` there. When the editor is based on an existing knowledge model, its language is used by default.
+We can create a new knowledge model editor either from scratch, i.e. the new knowledge model will be empty and we will build it all ourselves, or based on an existing knowledge model, which means that everything from the chosen knowledge model will be copied to ours. We can start from there and add, delete, or modify the existing entities in there. We just need to choose the original knowledge model in the **Based on** field. Alternatively, we can open the :ref:`knowledge model detail<km-detail>` and click on :guilabel:`Fork KM` there.
 
 We can only have one knowledge model editor with the same knowledge model ID. If we deleted the editor but want to continue working on that knowledge model, we can create a new editor with the same knowledge model ID. Or we can open the :ref:`knowledge model detail<km-detail>` and click on :guilabel:`Create KM editor` there to have the editor create form prefilled.

--- a/docs/application/knowledge-models/editors/create.rst
+++ b/docs/application/knowledge-models/editors/create.rst
@@ -11,12 +11,12 @@ We can create a new knowledge model editor by navigating to :menuselection:`Know
     Form for creating a new knowledge model.
 
 
-Every knowledge model needs to have a **name**, a **knowledge model ID** and **version**. The name should be something descriptive to help users understand what the knowledge model is about. The knowledge model ID is used for the identification together with the :ref:`organization ID<organization-settings>` and knowledge model version after it is published. So the identifier of the knowledge model is: 
+Every knowledge model needs to have a **name**, a **knowledge model ID**, **version**, and **language**. The name should be something descriptive to help users understand what the knowledge model is about. The language is the source language of the knowledge model content. The knowledge model ID is used for the identification together with the :ref:`organization ID<organization-settings>` and knowledge model version after it is published. So the identifier of the knowledge model is:
 
 .. code::
 
     <organizationId>:<knowledgeModelId>:<version>
 
-We can create a new knowledge model editor either from scratch, i.e. the new knowledge model will be empty and we will build it all ourselves, or based on an existing knowledge model, which means that everything from the chosen knowledge model will be copied to ours. We can start from there and add, delete, or modify the existing entities in there. We just need to choose the original knowledge model in the **Based on** field. Alternatively, we can open the :ref:`knowledge model detail<km-detail>` and click on :guilabel:`Fork KM` there.
+We can create a new knowledge model editor either from scratch, i.e. the new knowledge model will be empty and we will build it all ourselves, or based on an existing knowledge model, which means that everything from the chosen knowledge model will be copied to ours. We can start from there and add, delete, or modify the existing entities in there. We just need to choose the original knowledge model in the **Based on** field. Alternatively, we can open the :ref:`knowledge model detail<km-detail>` and click on :guilabel:`Fork KM` there. When the editor is based on an existing knowledge model, its language is used by default.
 
 We can only have one knowledge model editor with the same knowledge model ID. If we deleted the editor but want to continue working on that knowledge model, we can create a new editor with the same knowledge model ID. Or we can open the :ref:`knowledge model detail<km-detail>` and click on :guilabel:`Create KM editor` there to have the editor create form prefilled.

--- a/docs/application/knowledge-models/editors/detail/publish.rst
+++ b/docs/application/knowledge-models/editors/detail/publish.rst
@@ -7,8 +7,6 @@ Before the knowledge model can be used by researchers in their projects, we need
 
 If we click the button, we are prompted with the metadata details to check them before publishing. We cannot change anything here, so if we want to change it, we have to click the link to :guilabel:`Settings` or press :guilabel:`Cancel` and edit the details on the :guilabel:`Settings` tab of the :ref:`Knowledge Model Editor<knowledge-model-editor>`.
 
-If there are :ref:`translations<knowledge-model-translations>` available for the previous version or parent knowledge model, the publish dialog can offer to reuse them for the new version. We should reuse only translations that still match the updated knowledge model content. If the questionnaire text changed significantly, it is safer to update the translations after publishing.
-
 .. figure:: publish/publish-modal.png
     :width: 528
     

--- a/docs/application/knowledge-models/editors/detail/publish.rst
+++ b/docs/application/knowledge-models/editors/detail/publish.rst
@@ -7,6 +7,8 @@ Before the knowledge model can be used by researchers in their projects, we need
 
 If we click the button, we are prompted with the metadata details to check them before publishing. We cannot change anything here, so if we want to change it, we have to click the link to :guilabel:`Settings` or press :guilabel:`Cancel` and edit the details on the :guilabel:`Settings` tab of the :ref:`Knowledge Model Editor<knowledge-model-editor>`.
 
+If there are :ref:`translations<knowledge-model-translations>` available for the previous version or parent knowledge model, the publish dialog can offer to reuse them for the new version. We should reuse only translations that still match the updated knowledge model content. If the questionnaire text changed significantly, it is safer to update the translations after publishing.
+
 .. figure:: publish/publish-modal.png
     :width: 528
     

--- a/docs/application/knowledge-models/editors/detail/publish.rst
+++ b/docs/application/knowledge-models/editors/detail/publish.rst
@@ -12,8 +12,8 @@ If there are :ref:`locales<knowledge-model-locales>` available for the previous 
 .. figure:: publish/publish-modal.png
     :width: 528
     
-    Publish dialog where we can confirm or cancel publishing of the Knowledge Model.
+    Publish dialog where we can confirm or cancel publishing of the knowledge model.
 
-If we confirm the publishing of the Knowledge Model by clicking :guilabel:`Publish` in the modal window, the Knowledge Model becomes available to all users and is accessible in :ref:`Knowledge Model List<knowledge-model-list>`.
+If we confirm the publishing of the knowledge model by clicking :guilabel:`Publish` in the modal window, the knowledge model becomes available to all users and is accessible in :ref:`Knowledge Model List<knowledge-model-list>`.
 
 The Knowledge Model Editor will remain in the :ref:`Knowledge Model Editors<knowledge-model-editors>` list and will be available for any future changes.

--- a/docs/application/knowledge-models/editors/detail/publish.rst
+++ b/docs/application/knowledge-models/editors/detail/publish.rst
@@ -7,7 +7,7 @@ Before the knowledge model can be used by researchers in their projects, we need
 
 If we click the button, we are prompted with the metadata details to check them before publishing. We cannot change anything here, so if we want to change it, we have to click the link to :guilabel:`Settings` or press :guilabel:`Cancel` and edit the details on the :guilabel:`Settings` tab of the :ref:`Knowledge Model Editor<knowledge-model-editor>`.
 
-If there are :ref:`translations<knowledge-model-translations>` available for the previous version or parent knowledge model, the publish dialog can offer to reuse them for the new version. We should reuse only translations that still match the updated knowledge model content. If the questionnaire text changed significantly, it is safer to update the translations after publishing.
+If there are :ref:`locales<knowledge-model-locales>` available for the previous version or parent knowledge model, the publish dialog can offer to copy them to the new version. We should copy only locales that still match the updated knowledge model content. If the questionnaire text changed significantly, it is safer to update the locales after publishing.
 
 .. figure:: publish/publish-modal.png
     :width: 528

--- a/docs/application/knowledge-models/editors/detail/settings.rst
+++ b/docs/application/knowledge-models/editors/detail/settings.rst
@@ -7,7 +7,7 @@ The :guilabel:`Settings` tab, allows us to adjust attributes of the the knowledg
 - **Description** - this should be really short and descriptive.
 - **Knowledge Model ID** - is an unique Knowledge Model identifier.
 - **Version** - this is a number indicating which is the latest version of the Knowledge Model, because it can change over time.
-- **Language** - is the source language of the knowledge model content. It is used as the default questionnaire language and as the source language for knowledge model translations.
+- **Language** - is the source language of the knowledge model content. It is used as the default questionnaire language and as the source language for knowledge model locales.
 - **License** - this is used when we want to share the knowledge model with other people so they know how they can do that. We recommend using a license identifier from `SPDX License List <https://spdx.org/licenses/>`_.
 - **Readme** - this is where we can describe everything we need about the knowledge model. We can, for example, include a changelog of what changed in which version, etc. We can use :ref:`Markdown<markdown-cheatsheet>` in this field to provide some nice formatting.
 

--- a/docs/application/knowledge-models/editors/detail/settings.rst
+++ b/docs/application/knowledge-models/editors/detail/settings.rst
@@ -7,6 +7,7 @@ The :guilabel:`Settings` tab, allows us to adjust attributes of the the knowledg
 - **Description** - this should be really short and descriptive.
 - **Knowledge Model ID** - is an unique Knowledge Model identifier.
 - **Version** - this is a number indicating which is the latest version of the Knowledge Model, because it can change over time.
+- **Language** - is the source language of the knowledge model content. It is used as the default questionnaire language and as the source language for knowledge model translations.
 - **License** - this is used when we want to share the knowledge model with other people so they know how they can do that. We recommend using a license identifier from `SPDX License List <https://spdx.org/licenses/>`_.
 - **Readme** - this is where we can describe everything we need about the knowledge model. We can, for example, include a changelog of what changed in which version, etc. We can use :ref:`Markdown<markdown-cheatsheet>` in this field to provide some nice formatting.
 

--- a/docs/application/knowledge-models/editors/detail/settings.rst
+++ b/docs/application/knowledge-models/editors/detail/settings.rst
@@ -3,17 +3,17 @@ Settings
 
 The :guilabel:`Settings` tab allows us to adjust attributes of the knowledge model:
 
-- **Name** - should be short name of the Knowledge Model.
+- **Name** - should be short name of the knowledge model.
 - **Description** - this should be really short and descriptive.
-- **Knowledge Model ID** - is a unique Knowledge Model identifier.
-- **Version** - this is a number indicating which is the latest version of the Knowledge Model, because it can change over time.
+- **Knowledge Model ID** - is a unique knowledge model identifier.
+- **Version** - this is a number indicating which is the latest version of the knowledge model, because it can change over time.
 - **Language** - is the source language of the knowledge model content. It is used as the default questionnaire language and as the source language for knowledge model locales.
 - **License** - this is used when we want to share the knowledge model with other people so they know how they can do that. We recommend using a license identifier from `SPDX License List <https://spdx.org/licenses/>`_.
 - **Readme** - this is where we can describe everything we need about the knowledge model. We can, for example, include a changelog of what changed in which version, etc. We can use :ref:`Markdown<markdown-cheatsheet>` in this field to provide some nice formatting.
 
 .. NOTE::
 
-    **Name**, **Description** and **Version** are all visible to the researcher, when they select a Knowledge Model for their project. So the **Name** and **Description** should provide them with enough information to select a correct one.
+    **Name**, **Description** and **Version** are all visible to the researcher, when they select a knowledge model for their project. So the **Name** and **Description** should provide them with enough information to select a correct one.
 
     **Knowledge Model ID** together with the :ref:`organization ID<organization-settings>` and knowledge model version after it is published are used for the identification. So the identifier of the knowledge model is: 
 
@@ -30,4 +30,4 @@ In the **Danger Zone** we can delete the knowledge model. Once it is deleted it 
 
 .. figure:: settings/settings-form.png
     
-    Knowledge Model settings.
+    Knowledge model settings.

--- a/docs/application/knowledge-models/editors/detail/settings.rst
+++ b/docs/application/knowledge-models/editors/detail/settings.rst
@@ -7,7 +7,6 @@ The :guilabel:`Settings` tab, allows us to adjust attributes of the the knowledg
 - **Description** - this should be really short and descriptive.
 - **Knowledge Model ID** - is an unique Knowledge Model identifier.
 - **Version** - this is a number indicating which is the latest version of the Knowledge Model, because it can change over time.
-- **Language** - is the source language of the knowledge model content. It is used as the default questionnaire language and as the source language for knowledge model translations.
 - **License** - this is used when we want to share the knowledge model with other people so they know how they can do that. We recommend using a license identifier from `SPDX License List <https://spdx.org/licenses/>`_.
 - **Readme** - this is where we can describe everything we need about the knowledge model. We can, for example, include a changelog of what changed in which version, etc. We can use :ref:`Markdown<markdown-cheatsheet>` in this field to provide some nice formatting.
 

--- a/docs/application/knowledge-models/editors/detail/settings.rst
+++ b/docs/application/knowledge-models/editors/detail/settings.rst
@@ -1,11 +1,11 @@
 Settings
 ********
 
-The :guilabel:`Settings` tab, allows us to adjust attributes of the the knowledge model:
+The :guilabel:`Settings` tab allows us to adjust attributes of the knowledge model:
 
 - **Name** - should be short name of the Knowledge Model.
 - **Description** - this should be really short and descriptive.
-- **Knowledge Model ID** - is an unique Knowledge Model identifier.
+- **Knowledge Model ID** - is a unique Knowledge Model identifier.
 - **Version** - this is a number indicating which is the latest version of the Knowledge Model, because it can change over time.
 - **Language** - is the source language of the knowledge model content. It is used as the default questionnaire language and as the source language for knowledge model locales.
 - **License** - this is used when we want to share the knowledge model with other people so they know how they can do that. We recommend using a license identifier from `SPDX License List <https://spdx.org/licenses/>`_.

--- a/docs/application/knowledge-models/editors/migration.rst
+++ b/docs/application/knowledge-models/editors/migration.rst
@@ -58,7 +58,7 @@ We can cancel the knowledge model migration at any point before we publish the n
 Finishing a Knowledge Model Migration
 =====================================
 
-After we resolve all the changes, we are ready to publish the new version of the Child KM. To do that, we need to click on the :guilabel:`Publish →` button. This will open the Publish new version screen where we need to provide additional information for the new version of the Knowledge Model.
+After we resolve all the changes, we are ready to publish the new version of the Child KM. To do that, we need to click on the :guilabel:`Publish →` button. This will open the Publish new version screen where we need to provide additional information for the new version of the knowledge model.
 
 The publish screen shows us some information about the knowledge model, such as it's **Knowledge Model Name** and **Knowledge Model ID**. We need to choose the new **version number**.
 

--- a/docs/application/knowledge-models/list/detail.rst
+++ b/docs/application/knowledge-models/list/detail.rst
@@ -14,11 +14,11 @@ In the top bar, we can :guilabel:`Export` the knowledge model as a KM file or :g
 Translations
 ============
 
-A knowledge model has a source language and a published version can have translations for additional languages. These translations are used in projects to show the questionnaire content in the selected language without creating a separate translated fork of the knowledge model.
+A knowledge model has a source language and a published version can have translations for additional languages. These translations are used in projects to show the questionnaire content in the selected language.
 
 Translations are managed for a specific knowledge model version. From the knowledge model detail, users with permission to manage knowledge models can download a translation template, add a translated language, download an existing translation file, or delete a translation.
 
-The translation template is a POT file generated from the published knowledge model. It contains translatable strings from the knowledge model content, such as names, descriptions, answer labels, advice, and resource pages. Translators use this template to prepare a PO file for the target language. The PO file must include a ``Language`` header so DSW can identify the language code.
+The translation template is a POT file generated from the published knowledge model. It contains translatable strings from the knowledge model content, such as names, descriptions, answer labels, advice, and resource pages. Translators use this template to prepare a PO file for the target language.
 
 When a new knowledge model version is published, translations from the previous version or parent knowledge model can be reused during publishing if they are still valid. If knowledge model texts changed, the translation should be reviewed and updated for the new version.
 

--- a/docs/application/knowledge-models/list/detail.rst
+++ b/docs/application/knowledge-models/list/detail.rst
@@ -25,10 +25,11 @@ When a new knowledge model version is published, locales from the previous versi
 In the top pane, we can see the options based on our permissions:
 
 - :guilabel:`Preview` can be used to check the content of the KM via the :doc:`./preview` feature.
-- :guilabel:`Export` for exporting the latest version of the KM as a file.
+- :guilabel:`Export` for exporting the current version of the KM as a file.
+- :guilabel:`Export .pot file` for exporting the translation template for the current version of the KM.
 - :guilabel:`Compare` for comparing the current version of the KM with another version (see :doc:`./compare`).
 - :guilabel:`Create KM editor` is a shortcut for :doc:`../editors/create` for creating a new version.
-- :guilabel:`Fork KM` is again a shortcut for :doc:`../editors/create` for to create a fork (some more specific KM based on this one).
+- :guilabel:`Fork KM` is again a shortcut for :doc:`../editors/create` to create a fork (some more specific KM based on this one).
 - :guilabel:`Create project` is a shortcut to :doc:`../../projects/list/create` with this KM.
 - :guilabel:`Set deprecated` or :guilabel:`Restore` for setting a KM deprecated when we no longer want users to use it for new projects.
 - :guilabel:`Set public` or :guilabel:`Set private` for changing the visibility of the KM. Public KM can be viewed by non-logged in users.

--- a/docs/application/knowledge-models/list/detail.rst
+++ b/docs/application/knowledge-models/list/detail.rst
@@ -9,18 +9,18 @@ The main part of the detail is the README of the KM that should contain basic in
 
 In the top bar, we can :guilabel:`Export` the knowledge model as a KM file or :guilabel:`Delete` this version of the knowledge model (only if it is not already used for some projects or other KMs and editors).
 
-.. _knowledge-model-translations:
+.. _knowledge-model-locales:
 
-Translations
-============
+Locales
+========
 
-A knowledge model has a source language and a published version can have translations for additional languages. These translations are used in projects to show the questionnaire content in the selected language.
+A knowledge model has a source language and a published version can have locales for additional languages. These locales are used in projects to show the questionnaire content in the selected language.
 
-Translations are managed for a specific knowledge model version. From the knowledge model detail, users with permission to manage knowledge models can download a translation template, add a translated language, download an existing translation file, or delete a translation.
+Locales are managed for a specific knowledge model version. From the knowledge model detail, users with permission to manage knowledge models can export a POT file, import a locale, download an existing locale, or delete a locale.
 
-The translation template is a POT file generated from the published knowledge model. It contains translatable strings from the knowledge model content, such as names, descriptions, answer labels, advice, and resource pages. Translators use this template to prepare a PO file for the target language.
+The exported POT file contains translatable strings from the knowledge model content, such as names, descriptions, answer labels, advice, and resource pages. Translators use this file to prepare a PO file for the target language.
 
-When a new knowledge model version is published, translations from the previous version or parent knowledge model can be reused during publishing if they are still valid. If knowledge model texts changed, the translation should be reviewed and updated for the new version.
+When a new knowledge model version is published, locales from the previous version or parent knowledge model can be copied during publishing if they are still valid. If knowledge model texts changed, the locale should be reviewed and updated for the new version.
 
 In the top pane, we can see the options based on our permissions:
 

--- a/docs/application/knowledge-models/list/detail.rst
+++ b/docs/application/knowledge-models/list/detail.rst
@@ -9,6 +9,19 @@ The main part of the detail is the README of the KM that should contain basic in
 
 In the top bar, we can :guilabel:`Export` the knowledge model as a KM file or :guilabel:`Delete` this version of the knowledge model (only if it is not already used for some projects or other KMs and editors).
 
+.. _knowledge-model-translations:
+
+Translations
+============
+
+A knowledge model has a source language and a published version can have translations for additional languages. These translations are used in projects to show the questionnaire content in the selected language without creating a separate translated fork of the knowledge model.
+
+Translations are managed for a specific knowledge model version. From the knowledge model detail, users with permission to manage knowledge models can download a translation template, add a translated language, download an existing translation file, or delete a translation.
+
+The translation template is a POT file generated from the published knowledge model. It contains translatable strings from the knowledge model content, such as names, descriptions, answer labels, advice, and resource pages. Translators use this template to prepare a PO file for the target language. The PO file must include a ``Language`` header so DSW can identify the language code.
+
+When a new knowledge model version is published, translations from the previous version or parent knowledge model can be reused during publishing if they are still valid. If knowledge model texts changed, the translation should be reviewed and updated for the new version.
+
 In the top pane, we can see the options based on our permissions:
 
 - :guilabel:`Preview` can be used to check the content of the KM via the :doc:`./preview` feature.

--- a/docs/application/knowledge-models/list/detail.rst
+++ b/docs/application/knowledge-models/list/detail.rst
@@ -9,19 +9,6 @@ The main part of the detail is the README of the KM that should contain basic in
 
 In the top bar, we can :guilabel:`Export` the knowledge model as a KM file or :guilabel:`Delete` this version of the knowledge model (only if it is not already used for some projects or other KMs and editors).
 
-.. _knowledge-model-translations:
-
-Translations
-============
-
-A knowledge model has a source language and a published version can have translations for additional languages. These translations are used in projects to show the questionnaire content in the selected language without creating a separate translated fork of the knowledge model.
-
-Translations are managed for a specific knowledge model version. From the knowledge model detail, users with permission to manage knowledge models can download a translation template, add a translated language, download an existing translation file, or delete a translation.
-
-The translation template is a POT file generated from the published knowledge model. It contains translatable strings from the knowledge model content, such as names, descriptions, answer labels, advice, and resource pages. Translators use this template to prepare a PO file for the target language. The PO file must include a ``Language`` header so DSW can identify the language code.
-
-When a new knowledge model version is published, translations from the previous version or parent knowledge model can be reused during publishing if they are still valid. If knowledge model texts changed, the translation should be reviewed and updated for the new version.
-
 In the top pane, we can see the options based on our permissions:
 
 - :guilabel:`Preview` can be used to check the content of the KM via the :doc:`./preview` feature.

--- a/docs/application/knowledge-models/list/detail.rst
+++ b/docs/application/knowledge-models/list/detail.rst
@@ -14,11 +14,11 @@ In the top bar, we can :guilabel:`Export` the knowledge model as a KM file or :g
 Translations
 ============
 
-A knowledge model has a source language and a published version can have translations for additional languages. These translations are used in projects to show the questionnaire content in the selected language.
+A knowledge model has a source language and a published version can have translations for additional languages. These translations are used in projects to show the questionnaire content in the selected language without creating a separate translated fork of the knowledge model.
 
 Translations are managed for a specific knowledge model version. From the knowledge model detail, users with permission to manage knowledge models can download a translation template, add a translated language, download an existing translation file, or delete a translation.
 
-The translation template is a POT file generated from the published knowledge model. It contains translatable strings from the knowledge model content, such as names, descriptions, answer labels, advice, and resource pages. Translators use this template to prepare a PO file for the target language.
+The translation template is a POT file generated from the published knowledge model. It contains translatable strings from the knowledge model content, such as names, descriptions, answer labels, advice, and resource pages. Translators use this template to prepare a PO file for the target language. The PO file must include a ``Language`` header so DSW can identify the language code.
 
 When a new knowledge model version is published, translations from the previous version or parent knowledge model can be reused during publishing if they are still valid. If knowledge model texts changed, the translation should be reviewed and updated for the new version.
 

--- a/docs/application/knowledge-models/list/index.rst
+++ b/docs/application/knowledge-models/list/index.rst
@@ -42,7 +42,7 @@ Finally, there is an option to :doc:`./import` by clicking the :guilabel:`Import
 
 .. NOTE::
 
-    Set deprecated option will apply only for the latest version of Knowledge Model. If there is an older version, that will still be available.
+    Set deprecated option will apply only for the latest version of the knowledge model. If there is an older version, that will still be available.
 
 .. raw:: html
     

--- a/docs/application/knowledge-models/list/index.rst
+++ b/docs/application/knowledge-models/list/index.rst
@@ -3,16 +3,17 @@
 Knowledge Model List
 ********************
 
-Users with permission to manage knowledge models can manage the knowledge models that are in our DSW. We can access the list of knowledge model from the main menu via :guilabel:`Knowledge Model`. The list can be filtered and sorted by name or creation date. We can also search for a specific knowledge model by its id, name or version. The list shows the name, version, id, author, description and last update.
+Users with permission to manage knowledge models can manage the knowledge models that are in our DSW. We can access the list of knowledge models from the main menu via :guilabel:`Knowledge Models`. The list can be filtered and sorted by name or creation date. We can also search for a specific knowledge model by its id, name or version. The list shows the name, version, id, author, description and last update.
 
 For each knowledge model (KM), we can see the latest version in the list. If we want to read more about a specific KM or see the older versions, we need to access the :doc:`./detail` by clicking the name of KM or clicking :guilabel:`Open` from the right item menu (three dots). There are also other options for each item:
 
 - :guilabel:`Open` for opening the KM detail (same as clicking the name of the KM).
 - :guilabel:`Preview` to see how :doc:`../../projects/index` generated using this KM would look like.
-- :guilabel:`Export` for exporting the latest version of the KM as a file.
+- :guilabel:`Export` for exporting the listed version of the KM as a file.
+- :guilabel:`Export .pot file` for exporting the translation template for the listed version of the KM.
 - :guilabel:`Compare` for comparing the current version of the KM with another version (see :doc:`./compare`).
 - :guilabel:`Create KM editor` is a shortcut for :doc:`../editors/create` for creating a new version.
-- :guilabel:`Fork KM` is again a shortcut for :doc:`../editors/create` for to create a fork (some more specific KM based on this one).
+- :guilabel:`Fork KM` is again a shortcut for :doc:`../editors/create` to create a fork (some more specific KM based on this one).
 - :guilabel:`Create project` is a shortcut to :doc:`../../projects/list/create` with this KM.
 - :guilabel:`Set deprecated` or :guilabel:`Restore` for setting a KM deprecated when we no longer want users to use it for new projects.
 - :guilabel:`Set public` or :guilabel:`Set private` for changing the visibility of the KM. Public KM can be viewed by non-logged in users.
@@ -25,7 +26,7 @@ For each knowledge model (KM), we can see the latest version in the list. If we 
     This action is irreversible, so be careful when using it.
 
 
-If a newer version of the knowledge model is available in the `DSW Registry <https://registry.ds-wizard.org/>`__, a yellow :guilabel:`update available` badge, which we can use for quick update of the template to the latest version, will appear.
+If a newer version of the knowledge model is available in the `DSW Registry <https://registry.ds-wizard.org/>`__, a yellow :guilabel:`update available` badge, which we can use for a quick update to the latest version, will appear.
 
 Finally, there is an option to :doc:`./import` by clicking the :guilabel:`Import` button in the top right part of the screen.
 
@@ -33,10 +34,6 @@ Finally, there is an option to :doc:`./import` by clicking the :guilabel:`Import
 
     You can import multiple knowledge models from file at once.
 
-
-For users with permission to manage knowledge models, :guilabel:`update available` badge may appear if there is a newer version of the knowledge model in the `DSW Registry <https://registry.ds-wizard.org>`__ (and if configured).
-
-Finally, there is an option to :doc:`./import` by click the :guilabel:`Import` button in the top right part of the screen.
 
 .. figure:: index/list.png
     

--- a/docs/application/profile/settings/language.rst
+++ b/docs/application/profile/settings/language.rst
@@ -6,5 +6,3 @@ Language
 After navigating to :guilabel:`Language` from the :doc:`../index` menu, we can change the language of the DSW UI and emails. The preferred language is determined in the following order: the user's profile settings, then browser settings, and finally the default system language if the previous options are not set.
 
 We can select one of the available languages and click :guilabel:`Save` button to apply the changes.
-
-This setting does not automatically translate questionnaire content from a knowledge model. If the project uses a knowledge model with :ref:`translations<knowledge-model-translations>`, the questionnaire language is selected when creating the project or in the project settings.

--- a/docs/application/profile/settings/language.rst
+++ b/docs/application/profile/settings/language.rst
@@ -6,3 +6,5 @@ Language
 After navigating to :guilabel:`Language` from the :doc:`../index` menu, we can change the language of the DSW UI and emails. The preferred language is determined in the following order: the user's profile settings, then browser settings, and finally the default system language if the previous options are not set.
 
 We can select one of the available languages and click :guilabel:`Save` button to apply the changes.
+
+This setting does not automatically translate questionnaire content from a knowledge model. If the project uses a knowledge model with :ref:`translations<knowledge-model-translations>`, the questionnaire language is selected when creating the project or in the project settings.

--- a/docs/application/profile/settings/language.rst
+++ b/docs/application/profile/settings/language.rst
@@ -7,4 +7,4 @@ After navigating to :guilabel:`Language` from the :doc:`../index` menu, we can c
 
 We can select one of the available languages and click :guilabel:`Save` button to apply the changes.
 
-This setting does not automatically translate questionnaire content from a knowledge model. If the project uses a knowledge model with :ref:`translations<knowledge-model-translations>`, the questionnaire language is selected when creating the project or in the project settings.
+This setting does not automatically translate questionnaire content from a knowledge model. If the project uses a knowledge model with :ref:`locales<knowledge-model-locales>`, the questionnaire language is selected when creating the project or in the project settings.

--- a/docs/application/projects/list/create.rst
+++ b/docs/application/projects/list/create.rst
@@ -38,8 +38,6 @@ If there are no project templates available or we don't want to use them, we can
 
 If the knowledge model has :ref:`question tags<question-tag>`, we can either choose to create questionnaire with all available questions or filter them by the question tags.
 
-If the knowledge model has :ref:`translations<knowledge-model-translations>`, we can choose the questionnaire language. The source language of the knowledge model is selected by default. The language selection is shown only when there is at least one translation available for the selected knowledge model.
-
 .. figure:: create/project-create-custom.png
     :width: 528
     

--- a/docs/application/projects/list/create.rst
+++ b/docs/application/projects/list/create.rst
@@ -38,6 +38,8 @@ If there are no project templates available or we don't want to use them, we can
 
 If the knowledge model has :ref:`question tags<question-tag>`, we can either choose to create questionnaire with all available questions or filter them by the question tags.
 
+If the knowledge model has :ref:`translations<knowledge-model-translations>`, we can choose the questionnaire language. The source language of the knowledge model is selected by default. The language selection is shown only when there is at least one translation available for the selected knowledge model.
+
 .. figure:: create/project-create-custom.png
     :width: 528
     

--- a/docs/application/projects/list/create.rst
+++ b/docs/application/projects/list/create.rst
@@ -38,7 +38,7 @@ If there are no project templates available or we don't want to use them, we can
 
 If the knowledge model has :ref:`question tags<question-tag>`, we can either choose to create questionnaire with all available questions or filter them by the question tags.
 
-If the knowledge model has :ref:`translations<knowledge-model-translations>`, we can choose the questionnaire language. The source language of the knowledge model is selected by default. The language selection is shown only when there is at least one translation available for the selected knowledge model.
+If the knowledge model has :ref:`locales<knowledge-model-locales>`, we can choose the **Project Language**. The source language of the knowledge model is selected by default. The language selection is shown only when there is at least one locale available for the selected knowledge model.
 
 .. figure:: create/project-create-custom.png
     :width: 528

--- a/docs/application/projects/list/detail/metrics.rst
+++ b/docs/application/projects/list/detail/metrics.rst
@@ -8,7 +8,7 @@ In the :guilabel:`Metrics` tab in the project detail we can see a **Summary Repo
     Summary report of project metrics.
 
 
-The **Summary Report** shows how many questions are answered and unanswered in each chapter. It can either count all questions in the Knowledge Model or only the questions required for the project’s current phase. Questions from later phases are ignored in the phase-based view. If a parent question is unanswered, its child questions are not counted separately. Chapter results are combined into the total **Summary Report**.
+The **Summary Report** shows how many questions are answered and unanswered in each chapter. It can either count all questions in the knowledge model or only the questions required for the project’s current phase. Questions from later phases are ignored in the phase-based view. If a parent question is unanswered, its child questions are not counted separately. Chapter results are combined into the total **Summary Report**.
 
 If there are any metrics in the knowledge model, the report also shows the score for each metric. The score is calculated as a weighted average of all the answers affecting that metric and is always between 0 and 1. If there are at least 3 metrics present, a spider chart is also displayed.
 

--- a/docs/application/projects/list/detail/settings.rst
+++ b/docs/application/projects/list/detail/settings.rst
@@ -37,13 +37,6 @@ We can use the project as a :ref:`project template<project-templates>`. If we en
 
 :guilabel:`Unsupported metamodel` badge can appear, when the document template is not compatible with the version of DSW. Users should contact the person responsible for document templates or instance administration in this case.
 
-Questionnaire Language
-======================
-
-If the project's knowledge model has :ref:`translations<knowledge-model-translations>`, we can choose the questionnaire language in project settings. The available options are the source language of the knowledge model and any translations added for that knowledge model version.
-
-Changing the questionnaire language changes the knowledge model texts shown in the questionnaire, such as questions, answer labels, descriptions, advice, and resource pages. It does not translate answers that users have typed into the project.
-
 Knowledge Model
 ===============
 

--- a/docs/application/projects/list/detail/settings.rst
+++ b/docs/application/projects/list/detail/settings.rst
@@ -28,7 +28,7 @@ We can set a **default document template** and a **default document format**. Th
 Project Template
 ================
 
-We can use the project as a :ref:`project template<project-templates>`. If we enable this option, users can use it when creating a new project :ref:`from project template<from-project-template>`. Note that we also need to make it visible for other logged-in users in :ref:`sharing<sharing>` settings.
+We can use the project as a :ref:`project template<project-templates>`. If we enable this option, users with access to the project can use it when creating a new project :ref:`from project template<from-project-template>`. Project templates follow the same :ref:`sharing<sharing>` policy as projects, so we should share the template with users who should be able to use it.
 
 .. NOTE::
 

--- a/docs/application/projects/list/detail/settings.rst
+++ b/docs/application/projects/list/detail/settings.rst
@@ -40,7 +40,7 @@ We can use the project as a :ref:`project template<project-templates>`. If we en
 Questionnaire Language
 ======================
 
-If the project's knowledge model has :ref:`translations<knowledge-model-translations>`, we can choose the questionnaire language in project settings. The available options are the source language of the knowledge model and any translations added for that knowledge model version.
+If the project's knowledge model has :ref:`locales<knowledge-model-locales>`, we can choose the questionnaire language in project settings. The available options are the source language of the knowledge model and any locales added for that knowledge model version.
 
 Changing the questionnaire language changes the knowledge model texts shown in the questionnaire, such as questions, answer labels, descriptions, advice, and resource pages. It does not translate answers that users have typed into the project.
 

--- a/docs/application/projects/list/detail/settings.rst
+++ b/docs/application/projects/list/detail/settings.rst
@@ -37,6 +37,13 @@ We can use the project as a :ref:`project template<project-templates>`. If we en
 
 :guilabel:`Unsupported metamodel` badge can appear, when the document template is not compatible with the version of DSW. Users should contact the person responsible for document templates or instance administration in this case.
 
+Questionnaire Language
+======================
+
+If the project's knowledge model has :ref:`translations<knowledge-model-translations>`, we can choose the questionnaire language in project settings. The available options are the source language of the knowledge model and any translations added for that knowledge model version.
+
+Changing the questionnaire language changes the knowledge model texts shown in the questionnaire, such as questions, answer labels, descriptions, advice, and resource pages. It does not translate answers that users have typed into the project.
+
 Knowledge Model
 ===============
 

--- a/docs/more/development/metamodel-schemas.rst
+++ b/docs/more/development/metamodel-schemas.rst
@@ -9,7 +9,7 @@ As Data Stewardship Wizard evolves, the internal structures may change during th
 KM Package (.km file)
 =====================
 
-File for import and export of Knowledge Models is a JSON file that contains all KM packages (lists of change events with additional metadata). The structure of events is versioned using the KM metamodel version number and migrations in DSW automatically update the KMs when needed. As said, files according to this schema can be exported from :doc:`../../application/knowledge-models/list/index` or :doc:`../../application/knowledge-models/list/detail` and then used for :doc:`../../application/knowledge-models/list/import`.
+File for import and export of knowledge models is a JSON file that contains all KM packages (lists of change events with additional metadata). The structure of events is versioned using the KM metamodel version number and migrations in DSW automatically update the KMs when needed. As said, files according to this schema can be exported from :doc:`../../application/knowledge-models/list/index` or :doc:`../../application/knowledge-models/list/detail` and then used for :doc:`../../application/knowledge-models/list/import`.
 
 +-------------------+---------------------------------------------------------------------------------------------------------------+------------------------------------------------------+-----------+
 | Metamodel Version | Schema file                                                                                                   | Changes (brief)                                      | Since     |


### PR DESCRIPTION
## Summary
- add user-facing documentation for knowledge model source language and translations
- document translation management on knowledge model detail pages
- document questionnaire language selection during custom project creation and in project settings
- clarify that DSW UI locales/profile language are separate from knowledge model translations

## Source
- Based on WEP0014: Translations for Knowledge Models
- Internal DB/API details from the WEP are intentionally not included in the user guide

## Verification
- git diff --check
- make html